### PR TITLE
Automatic song-switching and neater visualiser

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -101,7 +101,7 @@ namespace YAVSRG
             
             var test = new Discord.EventHandlers() { requestCallback = Discord.RichPresence.RequestHandler };
             Discord.Initialize("420320424199716864", ref test, true, "");
-            Utils.SetDiscordData("Just started playing", "Pick a song already!");
+            Utils.SetDiscordData("Just started playing", "Pick a song already!"); // these are cringy blake; i love it
         }
 
         public void ApplyWindowSettings(Options.General settings) //apply video settings

--- a/Gameplay/Mods/NoLN.cs
+++ b/Gameplay/Mods/NoLN.cs
@@ -59,6 +59,6 @@ namespace YAVSRG.Gameplay.Mods
             return data == "release" ? "NoReleases" : "NoHolds";
         }
 
-        public override string GetDescription(string data) { return  data == "release" ? "Disables the need to release the ends of hold notes with exact timing, as these are not given judgements.\nYou are still required to be holding them while hitting another other simultaneous notes." : "Removes all hold notes from a chart and replaces them with a tap note where they began."; }
+        public override string GetDescription(string data) { return  data == "release" ? "Disables the need to release the ends of hold notes with exact timing, as these are not given judgements.\nYou are still required to be holding them while hitting another other simultaneous notes." : "Releases: Removes the judgements on releasing LNs\nAll: Removes all LNs and replaces them with a tap note from where they began."; }
     }
 }

--- a/Interface/Screens/ScreenEditor.cs
+++ b/Interface/Screens/ScreenEditor.cs
@@ -19,7 +19,7 @@ namespace YAVSRG.Interface.Screens
         {
             base.OnEnter(prev);
             Game.Screens.Toolbar.SetState(WidgetState.NORMAL);
-            Game.Audio.SetRate(1.0);
+            Game.Audio.SetRate(1.0); 
         }
 
         public override void OnExit(Screen next)

--- a/Interface/Screens/ScreenGoals.cs
+++ b/Interface/Screens/ScreenGoals.cs
@@ -1,0 +1,30 @@
+﻿using OpenTK.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAVSRG.Interface.Widgets;
+using System.Diagnostics;
+using ManagedBass;
+using YAVSRG.Charts;
+using YAVSRG.Interface.Screens;
+using YAVSRG.Interface;
+
+namespace YAVSRG.Interface.Screens
+{
+    class ScreenGoals : Screen
+    {
+        public ScreenGoals() : base()
+        {
+            // as of now this does absolutely nothing but exist -- i'm going to familiarise myself with the widgets and then attempt to create a calenderised goal system.
+        }
+
+        public override void Draw(Rect bounds)
+        {
+            base.Draw(bounds);
+            bounds = GetBounds(bounds);
+            SpriteBatch.Font1.DrawCentredTextToFill("Goals (will) go here", new Rect(bounds.Left, bounds.Top + 100, bounds.Right, bounds.Top + 200), Game.Options.Theme.MenuFont);
+        }
+    }
+}

--- a/Interface/Screens/ScreenScore.cs
+++ b/Interface/Screens/ScreenScore.cs
@@ -78,7 +78,7 @@ namespace YAVSRG.Interface.Screens
         public override void OnEnter(Screen prev)
         {
             base.OnEnter(prev);
-            Game.Audio.OnPlaybackFinish = null;
+            Game.Audio.OnPlaybackFinish = Game.Audio.Stop;
             PacketScoreboard.OnReceive += HandleMultiplayerScoreboard;
         }
 
@@ -86,6 +86,7 @@ namespace YAVSRG.Interface.Screens
         {
             base.OnExit(next);
             PacketScoreboard.OnReceive -= HandleMultiplayerScoreboard;
+            Game.Audio.Play();
         }
 
         public bool ShouldSaveScore()

--- a/Interface/Screens/ScreenVisualiser.cs
+++ b/Interface/Screens/ScreenVisualiser.cs
@@ -77,8 +77,8 @@ namespace YAVSRG.Interface.Screens
                 }
                 level *= 0.15f;
                 level += 10f;
-                r1 = (300 - level * 0.2f) * l;
-                r2 = (300 + level) * l;
+                r1 = 0; // used in calculations for waveform inwards -- it does nothing rn because i tore it out ungracefully
+                r2 = (200 + level) * l; // used in calculations for waveform away diverging from logo
                 a1 = rotate + Math.PI / 192 * i;
                 for (int p = 0; p < 6; p++)
                 {

--- a/Interface/Toolbar.cs
+++ b/Interface/Toolbar.cs
@@ -34,6 +34,9 @@ namespace YAVSRG.Interface
             AddChild(
                 new Button("buttononline", "Multiplayer", () => { if (!(Game.Screens.Current is ScreenLobby) && !(Game.Screens.Current is ScreenScore)) Game.Screens.AddScreen(new ScreenLobby()); })
                 .PositionTopLeft(400, 0, AnchorType.MAX, AnchorType.MIN).PositionBottomRight(320, 80, AnchorType.MAX, AnchorType.MIN));
+            AddChild(
+                new Button("buttongoals", "Goals", () => { if (!(Game.Screens.Current is ScreenGoals) && !(Game.Screens.Current is ScreenScore)) Game.Screens.AddScreen(new ScreenGoals()); })
+                .PositionTopLeft(480, 0, AnchorType.MAX, AnchorType.MIN).PositionBottomRight(400, 80, AnchorType.MAX, AnchorType.MIN));
             Chat = new ChatBox();
             AddChild(Chat.PositionTopLeft(0, 80, AnchorType.MIN, AnchorType.MAX).PositionBottomRight(0, 80, AnchorType.MAX, AnchorType.MAX));
             AddChild(new TaskDisplay());
@@ -79,6 +82,7 @@ namespace YAVSRG.Interface
             if (_Height > 1)
             {
                 float s = (ScreenHeight * 2 - _Height * 2) / 24f;
+                
                 for (int i = 0; i < 24; i++) //draws the waveform
                 {
                     float level = Game.Audio.WaveForm[i * 4] + Game.Audio.WaveForm[i * 4 + 1] + Game.Audio.WaveForm[i * 4 + 2] + Game.Audio.WaveForm[i * 4 + 3];

--- a/Interface/Widgets/Controls/TextPicker.cs
+++ b/Interface/Widgets/Controls/TextPicker.cs
@@ -27,8 +27,8 @@ namespace YAVSRG.Interface.Widgets
             bounds = GetBounds(bounds);
             SpriteBatch.DrawRect(new Rect(bounds.Left, bounds.Top, bounds.Left + 20, bounds.Bottom), Game.Screens.BaseColor);
             SpriteBatch.DrawRect(new Rect(bounds.Right - 20, bounds.Top, bounds.Right, bounds.Bottom), Game.Screens.BaseColor);
-            SpriteBatch.Font1.DrawCentredText(options[selection], 30, bounds.CenterX, bounds.Top, Game.Options.Theme.MenuFont, true, Game.Screens.BaseColor);
-            SpriteBatch.Font2.DrawCentredText(label, 20, bounds.CenterX, bounds.Top - 30, Game.Options.Theme.MenuFont);
+            SpriteBatch.Font1.DrawCentredText(options[selection], 30, bounds.CenterX, bounds.Top, Game.Options.Theme.MenuFont, true, Game.Screens.DarkColor);
+            SpriteBatch.Font2.DrawCentredText(label, 20, bounds.CenterX, bounds.Top - 30, Game.Options.Theme.MenuFont, true, Game.Screens.DarkColor);
         }
 
         public override void Update(Rect bounds)

--- a/Interface/Widgets/Gameplay/HitMeter.cs
+++ b/Interface/Widgets/Gameplay/HitMeter.cs
@@ -110,7 +110,7 @@ namespace YAVSRG.Interface.Widgets.Gameplay
             float c = bounds.CenterX;
             foreach (Hit h in hits)
             {
-                SpriteBatch.DrawRect(new Rect(c + h.delta * 4 - 4, bounds.Bottom-40, c + h.delta * 4 + 4, bounds.Bottom), Color.FromArgb(Alpha(now - h.time), Game.Options.Theme.JudgeColors[h.tier]));
+                SpriteBatch.DrawRect(new Rect(c + h.delta * 4 - 4 * (Game.Instance.Width / 1920), bounds.Bottom-40, c + h.delta * 4 + 4, bounds.Bottom), Color.FromArgb(Alpha(now - h.time), Game.Options.Theme.JudgeColors[h.tier]));
             }
         }
 

--- a/Interface/Widgets/Logo.cs
+++ b/Interface/Widgets/Logo.cs
@@ -54,7 +54,7 @@ namespace YAVSRG.Interface.Widgets
 
             Game.Screens.DrawChartBackground(bounds, Color.FromArgb(a,Color.Aqua));
             SpriteBatch.DrawRect(bounds, Color.FromArgb((int)(alpha * 180), Color.Aqua));
-            SpriteBatch.DrawTilingTexture("rain", bounds, 320, animation.value * -0.0006f, animation.value * -0.0007f, color: Color.FromArgb((int)(alpha*80), Color.Blue));
+            SpriteBatch.DrawTilingTexture("rain", bounds, 320, animation.value * -0.0006f, animation.value * -0.0007f, color: Color.FromArgb((int)(alpha * 80), Color.Blue));
             SpriteBatch.DrawTilingTexture("rain", bounds, 512, animation.value * -0.001f, animation.value * -0.0011f, color: Color.FromArgb((int)(alpha * 150), Color.Blue));
             SpriteBatch.DrawTilingTexture("rain", bounds, 800, animation.value * -0.0015f, animation.value * -0.0016f, color: Color.FromArgb((int)(alpha * 220), Color.Blue));
 

--- a/Options/General.cs
+++ b/Options/General.cs
@@ -25,6 +25,7 @@ namespace YAVSRG.Options
             new Tuple<int, int>(1600, 900),
             new Tuple<int, int>(1600, 1024),
             new Tuple<int, int>(1680, 1050),
+            new Tuple<int, int>(1768, 992),
             new Tuple<int, int>(1920, 1080),
             new Tuple<int, int>(2715, 1527),
         };

--- a/Resources/MenuSplashes.txt
+++ b/Resources/MenuSplashes.txt
@@ -40,3 +40,4 @@ I really really really really hope you're playing on 16:9
 Who's the minigame now?
 Now watch me whip
 SC stands for Side Chick
+INITIAL COMMIT

--- a/SpriteFont.cs
+++ b/SpriteFont.cs
@@ -32,7 +32,7 @@ namespace YAVSRG
         {
             if (dropShadow)
             {
-                DrawText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(color.A, shadowColor), false);
+                DrawText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(color.A, shadowColor.R / 2, shadowColor.G / 2, shadowColor.B / 2), false);
             }
             float start = x;
             scale /= FONTSCALE;
@@ -43,7 +43,7 @@ namespace YAVSRG
                 if (!FontLookup.ContainsKey(c)) { GenChar(c); }
                 s = FontLookup[c];
                 SpriteBatch.Draw(sprite: s, bounds: new Rect(x, y, x + s.Width * scale, y + s.Height * scale), color: color);
-                x += (s.Width - FONTSCALE * 0.5f) * scale; //kerning
+                x += (s.Width - FONTSCALE * 0.5f) * scale; //keming
             }
             return x - start;
         }
@@ -52,7 +52,7 @@ namespace YAVSRG
         {
             if (dropShadow)
             {
-                DrawCentredText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(c.A, shadowColor), false);
+                DrawCentredText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(c.A, shadowColor.R / 2, shadowColor.G / 2, shadowColor.B / 2), false);
             }
             x -= scale / FONTSCALE * 0.5f * MeasureText(text);
             return DrawText(text, scale, x, y, c);
@@ -62,7 +62,7 @@ namespace YAVSRG
         {
             if (dropShadow)
             {
-                DrawJustifiedText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(c.A, shadowColor), false);
+                DrawJustifiedText(text, scale, x + scale * ShadowAmount, y + scale * ShadowAmount, Color.FromArgb(c.A, shadowColor.R / 2, shadowColor.G / 2, shadowColor.B / 2), false);
             }
             x -= scale / FONTSCALE * MeasureText(text);
             return DrawText(text, scale, x, y, c);


### PR DESCRIPTION
- Automatically switches songs on non-gameplay-relevant screens so as not to hear the same song on repeat for 10 years (uses nextsong function)
- visualiser no longer looks like you've ripped it out of the desecrated corpse of osu!lazer
- added groundwork for a goals screen (slight misnomer, is actually in depth player metrics)
- accidentally pushed a joke splash